### PR TITLE
Enable concurrent GPU workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # Hashmancer-Agent
+
+This repository contains the worker agent used with the Hashmancer-Server project. It registers GPUs, fetches tasks, runs hashcat, reports results, and sends health updates.
+
+## Modules
+- `task_fetcher.py` – fetch tasks from Redis according to GPU bandwidth
+- `hashcat_runner.py` – execute hashcat based on task details
+- `results_client.py` – send found hashes or completion reports
+- `watchdog_agent.py` – report GPU metrics and restart stalled tasks
+- `worker_manager.py` – coordinate fetching and running tasks on all GPUs
+- `setup_agent.py` – interactive setup and worker registration
+- `simple_worker.py` – spawn mask-only workers for GPUs with four or fewer PCIe lanes
+- `advanced_worker.py` – spawn workers for GPUs with x8/x16 links for dictionary and hybrid tasks
+
+The scripts rely on environment variables for server URL, API keys, and Redis connection details, making deployment flexible across various systems.
+
+## Setup
+
+Run `python -m hashmancer_agent.setup_agent` to configure the agent. The script
+installs Python dependencies from `requirements.txt` and attempts to install
+`hashcat` and NVIDIA drivers via `apt` before registering the worker with the
+server.

--- a/hashmancer_agent/__init__.py
+++ b/hashmancer_agent/__init__.py
@@ -1,0 +1,10 @@
+"""Hashmancer worker agent package."""
+__all__ = [
+    "task_fetcher",
+    "hashcat_runner",
+    "results_client",
+    "watchdog_agent",
+    "worker_manager",
+    "advanced_worker",
+    "setup_agent",
+]

--- a/hashmancer_agent/advanced_worker.py
+++ b/hashmancer_agent/advanced_worker.py
@@ -1,0 +1,51 @@
+"""Advanced worker for high-bandwidth GPUs (PCIe x8/x16).
+
+This script registers the worker, filters GPUs with >=8 lane width, and runs
+hashcat tasks using the normal worker manager components. It is intended for
+rigs that can handle dictionary and hybrid attacks in addition to mask mode.
+"""
+
+from multiprocessing import Process
+from typing import Dict, List
+
+from . import setup_agent, worker_manager, watchdog_agent
+
+
+class HighBWProcess(worker_manager.WorkerProcess):
+    """Worker process restricted to GPUs with x8+ PCIe width."""
+
+    def __init__(self, gpu: Dict[str, str], worker_id: str):
+        super().__init__(gpu, worker_id)
+
+
+def _filter_high_bandwidth(gpus: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    result = []
+    for gpu in gpus:
+        try:
+            width = int(gpu.get("pcie_width", 0))
+        except ValueError:
+            width = 0
+        if width >= 8:
+            result.append(gpu)
+    return result
+
+
+def main() -> None:
+    worker_id = setup_agent.register_worker()
+    gpu_info = _filter_high_bandwidth(setup_agent.collect_gpu_info())
+    if not gpu_info:
+        print("No GPUs with x8 or higher PCIe width detected.")
+        return
+
+    procs: List[Process] = [HighBWProcess(g, worker_id) for g in gpu_info]
+    for p in procs:
+        p.start()
+
+    watchdog_agent.run_watchdog(worker_id)
+
+    for p in procs:
+        p.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/hashmancer_agent/hashcat_runner.py
+++ b/hashmancer_agent/hashcat_runner.py
@@ -1,0 +1,43 @@
+import os
+import subprocess
+from pathlib import Path
+from typing import Dict
+
+from . import results_client
+
+HASHCAT_BIN = os.environ.get("HASHCAT_BIN", "hashcat")
+OUTPUT_DIR = Path(os.environ.get("OUTPUT_DIR", "outputs"))
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+
+def build_command(task: Dict[str, str], device: str | None = None) -> list[str]:
+    hashes = task.get("hashes")
+    mask = task.get("mask")
+    wordlist = task.get("wordlist")
+    mode = task.get("attack_mode", "mask")
+
+    cmd = [HASHCAT_BIN, "--potfile-disable"]
+    if device:
+        cmd += ["-d", str(device)]
+    if mode == "mask":
+        cmd += ["-a", "3", hashes, mask]
+    elif mode == "dict":
+        cmd += ["-a", "0", hashes, wordlist]
+    elif mode == "hybrid":
+        cmd += ["-a", "6", hashes, wordlist, mask]
+    return cmd
+
+
+def run_task(task: Dict[str, str], worker_id: str, device: str | None = None) -> None:
+    cmd = build_command(task, device)
+    output_file = OUTPUT_DIR / f"{worker_id}_found.txt"
+    env = os.environ.copy()
+    env["HC_OUTFILE"] = str(output_file)
+
+    proc = subprocess.run(cmd, env=env, capture_output=True, text=True)
+    if output_file.exists() and output_file.stat().st_size > 0:
+        results_client.submit_founds(worker_id, output_file.read_text())
+    else:
+        results_client.submit_no_founds(worker_id)
+    if proc.returncode != 0:
+        print(proc.stderr)

--- a/hashmancer_agent/results_client.py
+++ b/hashmancer_agent/results_client.py
@@ -1,0 +1,55 @@
+import json
+import os
+from pathlib import Path
+from typing import Dict
+
+import requests
+
+try:
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import padding, rsa
+    from cryptography.hazmat.primitives import serialization
+except Exception:  # pragma: no cover
+    hashes = padding = rsa = serialization = None  # type: ignore
+
+SERVER_URL = os.environ.get("SERVER_URL", "http://localhost:8000")
+PRIVATE_KEY_FILE = Path(os.environ.get("PRIVATE_KEY_FILE", "worker_private.pem"))
+
+
+def _load_private_key():
+    if not PRIVATE_KEY_FILE.exists() or not serialization:
+        return None
+    data = PRIVATE_KEY_FILE.read_bytes()
+    return serialization.load_pem_private_key(data, password=None)
+
+
+def _sign_payload(data: bytes) -> str | None:
+    key = _load_private_key()
+    if not key:
+        return None
+    signature = key.sign(
+        data,
+        padding.PKCS1v15(),
+        hashes.SHA256(),
+    )
+    return signature.hex()
+
+
+def _post(endpoint: str, payload: Dict[str, str]):
+    body = json.dumps(payload).encode()
+    sig = _sign_payload(body)
+    headers = {"Content-Type": "application/json"}
+    if sig:
+        headers["X-Worker-Signature"] = sig
+    resp = requests.post(f"{SERVER_URL}{endpoint}", data=body, headers=headers, timeout=30)
+    resp.raise_for_status()
+
+
+def submit_founds(worker_id: str, founds: str):
+    payload = {"worker_id": worker_id, "founds": founds}
+    _post("/submit_founds", payload)
+
+
+def submit_no_founds(worker_id: str):
+    payload = {"worker_id": worker_id}
+    _post("/submit_no_founds", payload)

--- a/hashmancer_agent/setup_agent.py
+++ b/hashmancer_agent/setup_agent.py
@@ -1,0 +1,137 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Dict
+
+import requests
+
+
+CONFIG_FILE = Path(".env")
+SERVER_URL = os.environ.get("SERVER_URL", "http://localhost:8000")
+WORKER_ID_FILE = Path(os.environ.get("WORKER_ID_FILE", "worker_id"))
+PUBLIC_KEY_FILE = Path(os.environ.get("PUBLIC_KEY_FILE", "worker_public.pem"))
+
+
+def prompt(key: str, default: str = "") -> str:
+    """Prompt user for a value with an optional default."""
+    return input(f"{key} [{default}]: ") or default
+
+
+def write_config(server: str, redis_host: str, redis_port: str) -> None:
+    """Persist connection settings to the CONFIG_FILE."""
+    with CONFIG_FILE.open("w") as f:
+        f.write(f"SERVER_URL={server}\n")
+        f.write(f"REDIS_HOST={redis_host}\n")
+        f.write(f"REDIS_PORT={redis_port}\n")
+    print(f"Configuration written to {CONFIG_FILE}")
+
+
+def install_python_requirements() -> None:
+    """Install Python packages listed in requirements.txt."""
+    req = Path("requirements.txt")
+    if req.exists():
+        print("Installing Python dependencies...")
+        subprocess.run([sys.executable, "-m", "pip", "install", "-r", str(req)], check=False)
+
+
+def _have(cmd: str) -> bool:
+    return subprocess.run(["which", cmd], capture_output=True).returncode == 0
+
+
+def install_system_packages() -> None:
+    """Attempt to install hashcat and NVIDIA drivers using apt."""
+    if not _have("hashcat"):
+        print("Installing hashcat...")
+        subprocess.run(["sudo", "apt-get", "update"], check=False)
+        subprocess.run(["sudo", "apt-get", "-y", "install", "hashcat"], check=False)
+    if not _have("nvidia-smi"):
+        print("Installing NVIDIA drivers...")
+        subprocess.run(["sudo", "apt-get", "-y", "install", "nvidia-driver-525"], check=False)
+
+
+def _run_nvidia_smi() -> str:
+    """Return raw output from nvidia-smi or an empty string if unavailable."""
+    try:
+        return subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,name,memory.total,pci.link.width.max,memory.max_bandwidth,power.limit",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+
+
+def collect_gpu_info() -> List[Dict[str, str]]:
+    """Collect information for all detected GPUs."""
+    output = _run_nvidia_smi()
+    gpus: List[Dict[str, str]] = []
+    for line in output.strip().splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) >= 6:
+            idx, name, mem, pcie, bandwidth, power = parts[:6]
+        else:
+            values = (parts + [""] * 6)[:6]
+            idx, name, mem, pcie, bandwidth, power = values
+        gpus.append(
+            {
+                "index": idx,
+                "name": name,
+                "memory": mem,
+                "pcie_width": pcie,
+                "memory_bandwidth": bandwidth,
+                "power_limit": power,
+            }
+        )
+    return gpus
+
+
+def register_worker() -> str:
+    """Register this worker with the server and return the worker id."""
+    if WORKER_ID_FILE.exists():
+        return WORKER_ID_FILE.read_text().strip()
+
+    gpu_info = collect_gpu_info()
+    try:
+        pubkey = PUBLIC_KEY_FILE.read_text()
+    except FileNotFoundError:
+        pubkey = ""
+    payload = {"gpus": gpu_info, "public_key": pubkey}
+    resp = requests.post(f"{SERVER_URL}/register_worker", json=payload, timeout=30)
+    resp.raise_for_status()
+    worker_id = resp.json().get("waifu_name", "")
+    if worker_id:
+        WORKER_ID_FILE.write_text(worker_id)
+    return worker_id
+
+
+def main() -> None:
+    print("Hashmancer-Agent setup and registration")
+    global SERVER_URL
+    server = prompt("SERVER_URL", SERVER_URL)
+    redis_host = prompt("REDIS_HOST", os.environ.get("REDIS_HOST", "localhost"))
+    redis_port = prompt("REDIS_PORT", os.environ.get("REDIS_PORT", "6379"))
+
+    write_config(server, redis_host, redis_port)
+
+    install_python_requirements()
+    install_system_packages()
+
+    # update runtime configuration for immediate registration
+    SERVER_URL = server
+    os.environ["SERVER_URL"] = server
+
+    worker = register_worker()
+    if worker:
+        print(f"Registered worker id: {worker}")
+    else:
+        print("Worker registration failed")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/hashmancer_agent/simple_worker.py
+++ b/hashmancer_agent/simple_worker.py
@@ -1,0 +1,97 @@
+import os
+import json
+import time
+import subprocess
+from pathlib import Path
+
+import redis
+from multiprocessing import Process
+
+REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")
+REDIS_PORT = int(os.environ.get("REDIS_PORT", 6379))
+WORK_QUEUE = os.environ.get("WORK_QUEUE", "work_queue")
+RESULT_QUEUE = os.environ.get("RESULT_QUEUE", "results")
+HASH_MODE = os.environ.get("HASH_MODE", "0")  # MD5 by default
+MASK = os.environ.get("MASK", "?l?l?l?l?d?d")
+HASHCAT_BIN = os.environ.get("HASHCAT_BIN", "hashcat")
+HASH_FILE = Path("hashes.txt")
+
+
+def _redis_conn():
+    return redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
+
+def get_pcie_info():
+    try:
+        out = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,pci.bus_id,pci.link_width,pci.link_gen",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+        )
+        info = []
+        for line in out.strip().splitlines():
+            info.append(tuple(p.strip() for p in line.split(',')))
+        return info
+    except Exception:
+        return []
+
+
+def fetch_task(r):
+    data = r.lpop(WORK_QUEUE)
+    if not data:
+        return None
+    return json.loads(data)
+
+
+def run_hashcat(task_id, hashes, device):
+    HASH_FILE.write_text("\n".join(hashes))
+    output_file = f"cracked_{task_id}.txt"
+    cmd = [
+        HASHCAT_BIN, "-a", "3",
+        "-m", HASH_MODE,
+        str(HASH_FILE),
+        MASK,
+        "-d", str(device),
+        "--outfile", output_file,
+        "--quiet",
+        "--hwmon-temp-abort", "90",
+        "--gpu-temp-retain", "70",
+        "--force",
+    ]
+    subprocess.run(cmd)
+    if Path(output_file).exists():
+        results = Path(output_file).read_text().splitlines()
+        r = _redis_conn()
+        r.rpush(RESULT_QUEUE, json.dumps({"task_id": task_id, "results": results}))
+
+
+def worker_loop(device: str) -> None:
+    r = _redis_conn()
+    while True:
+        task = fetch_task(r)
+        if not task:
+            time.sleep(10)
+            continue
+        run_hashcat(task["id"], task["hashes"], device)
+
+
+def main():
+    pcie = get_pcie_info()
+    low_gpus = [(idx, bus, width, gen) for idx, bus, width, gen in pcie if int(width) <= 4]
+    if not low_gpus:
+        print("No low-bandwidth GPUs detected.")
+        return
+    procs = []
+    for idx, bus, width, gen in low_gpus:
+        print(f"GPU {bus} (index {idx}): x{width} Gen{gen}")
+        p = Process(target=worker_loop, args=(idx,))
+        p.start()
+        procs.append(p)
+    for p in procs:
+        p.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/hashmancer_agent/task_fetcher.py
+++ b/hashmancer_agent/task_fetcher.py
@@ -1,0 +1,23 @@
+import os
+from typing import Any, Dict
+import json
+import redis
+
+REDIS_HOST = os.environ.get("REDIS_HOST", "localhost")
+REDIS_PORT = int(os.environ.get("REDIS_PORT", "6379"))
+HIGH_QUEUE = os.environ.get("HIGH_QUEUE", "task:high")
+LOW_QUEUE = os.environ.get("LOW_QUEUE", "task:low")
+
+
+class TaskFetcher:
+    def __init__(self, pcie_width: int):
+        self.queue = HIGH_QUEUE if pcie_width >= 8 else LOW_QUEUE
+        self.r = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, decode_responses=True)
+
+    def fetch(self) -> Dict[str, Any]:
+        _, task_id = self.r.blpop(self.queue)
+        task_key = f"task:{task_id}"
+        data = self.r.get(task_key)
+        if not data:
+            return {}
+        return json.loads(data)

--- a/hashmancer_agent/watchdog_agent.py
+++ b/hashmancer_agent/watchdog_agent.py
@@ -1,0 +1,45 @@
+import os
+import subprocess
+import time
+from typing import Dict
+
+import requests
+
+SERVER_URL = os.environ.get("SERVER_URL", "http://localhost:8000")
+
+
+def get_gpu_metrics() -> Dict[str, str]:
+    try:
+        out = subprocess.check_output(
+            [
+                "nvidia-smi",
+                "--query-gpu=temperature.gpu,fan.speed,power.draw",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+        )
+        temps, fan, power = out.strip().split(',')
+        return {
+            "temperature": temps.strip(),
+            "fan_speed": fan.strip(),
+            "power_draw": power.strip(),
+        }
+    except Exception:
+        return {}
+
+
+def send_metrics(worker_id: str):
+    metrics = get_gpu_metrics()
+    if not metrics:
+        return
+    payload = {"worker_id": worker_id, "metrics": metrics}
+    try:
+        requests.post(f"{SERVER_URL}/log_watchdog_event", json=payload, timeout=15)
+    except requests.RequestException:
+        pass
+
+
+def run_watchdog(worker_id: str, interval: int = 60):
+    while True:
+        send_metrics(worker_id)
+        time.sleep(interval)

--- a/hashmancer_agent/worker_manager.py
+++ b/hashmancer_agent/worker_manager.py
@@ -1,0 +1,41 @@
+import multiprocessing as mp
+import os
+from typing import Dict
+
+from . import setup_agent, task_fetcher, hashcat_runner, watchdog_agent
+
+
+class WorkerProcess(mp.Process):
+    def __init__(self, gpu: Dict[str, str], worker_id: str):
+        super().__init__()
+        self.gpu = gpu
+        self.worker_id = worker_id
+
+    def run(self):
+        width = int(self.gpu.get("pcie_width", "0"))
+        device = self.gpu.get("index", "")
+        fetcher = task_fetcher.TaskFetcher(width)
+        if device:
+            os.environ["CUDA_VISIBLE_DEVICES"] = str(device)
+        while True:
+            task = fetcher.fetch()
+            if task:
+                hashcat_runner.run_task(task, self.worker_id, device)
+
+
+def main():
+    worker_id = setup_agent.register_worker()
+    gpu_info = setup_agent.collect_gpu_info()
+
+    procs = [WorkerProcess(gpu, worker_id) for gpu in gpu_info]
+    for p in procs:
+        p.start()
+
+    watchdog_agent.run_watchdog(worker_id)
+
+    for p in procs:
+        p.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+redis
+requests
+cryptography


### PR DESCRIPTION
## Summary
- allow per-GPU worker processes to set CUDA_VISIBLE_DEVICES
- add device option to hashcat_runner
- spawn mask-only processes per low-bandwidth GPU in `simple_worker`
- parse GPU indices during setup
- clarify worker scripts in README
- install dependencies from requirements and attempt installing system packages

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686ec96735648326a8fa116c8b07f42d