### PR TITLE
Add dependency automation to setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,9 @@ This repository contains the worker agent used with the Hashmancer-Server projec
 - `simple_worker.py` – spawn mask-only workers for GPUs with four or fewer PCIe lanes
 - `advanced_worker.py` – spawn workers for GPUs with x8/x16 links for dictionary and hybrid tasks
 
+## Requirements
+
+See [REQUIREMENTS.md](REQUIREMENTS.md) for a list of required packages. The
+`setup_agent.py` script will attempt to install them automatically.
+
 The scripts rely on environment variables for server URL, API keys, and Redis connection details, making deployment flexible across various systems.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,0 +1,17 @@
+# Requirements
+
+The agent requires several system and Python packages.
+
+System packages:
+- `redis-server`
+- `hashcat`
+- NVIDIA drivers providing `nvidia-smi`
+
+Python packages are listed in `requirements.txt` and include:
+- `redis`
+- `requests`
+- `cryptography`
+
+Running `python -m hashmancer_agent.setup_agent` will attempt to install
+these packages automatically using `apt-get` and `pip`.
+Ensure you have an internet connection and sufficient privileges.

--- a/hashmancer_agent/setup_agent.py
+++ b/hashmancer_agent/setup_agent.py
@@ -1,16 +1,22 @@
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 from typing import List, Dict
 
-import requests
+try:
+    import requests
+except ImportError:  # pragma: no cover - install missing dependency
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "requests"])
+    import requests
 
 
 CONFIG_FILE = Path(".env")
 SERVER_URL = os.environ.get("SERVER_URL", "http://localhost:8000")
 WORKER_ID_FILE = Path(os.environ.get("WORKER_ID_FILE", "worker_id"))
 PUBLIC_KEY_FILE = Path(os.environ.get("PUBLIC_KEY_FILE", "worker_public.pem"))
+REQUIREMENTS_FILE = Path("requirements.txt")
 
 
 def prompt(key: str, default: str = "") -> str:
@@ -25,6 +31,33 @@ def write_config(server: str, redis_host: str, redis_port: str) -> None:
         f.write(f"REDIS_HOST={redis_host}\n")
         f.write(f"REDIS_PORT={redis_port}\n")
     print(f"Configuration written to {CONFIG_FILE}")
+
+
+def _apt_install(pkgs: List[str]) -> None:
+    """Install system packages using apt-get."""
+    try:
+        subprocess.check_call(["apt-get", "update"])
+        subprocess.check_call(["apt-get", "install", "-y"] + pkgs)
+    except subprocess.CalledProcessError as exc:
+        print(f"Failed to install packages {pkgs}: {exc}")
+
+
+def _pip_install(requirements: Path) -> None:
+    try:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", str(requirements)])
+    except subprocess.CalledProcessError as exc:
+        print(f"Failed to install python packages: {exc}")
+
+
+def install_dependencies() -> None:
+    """Attempt to install required system and Python packages."""
+    if os.geteuid() == 0:
+        _apt_install(["redis-server", "hashcat", "nvidia-driver-535"])
+    else:
+        print("Skipping system package installation: not running as root")
+
+    if REQUIREMENTS_FILE.exists():
+        _pip_install(REQUIREMENTS_FILE)
 
 
 def _run_nvidia_smi() -> str:
@@ -87,6 +120,7 @@ def register_worker() -> str:
 
 def main() -> None:
     print("Hashmancer-Agent setup and registration")
+    install_dependencies()
     global SERVER_URL
     server = prompt("SERVER_URL", SERVER_URL)
     redis_host = prompt("REDIS_HOST", os.environ.get("REDIS_HOST", "localhost"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+redis
+requests
+cryptography


### PR DESCRIPTION
## Summary
- add dependency documentation
- list python requirements
- auto-install redis, hashcat, NVIDIA drivers and Python packages during setup
- link documentation from README

## Testing
- `python -m py_compile hashmancer_agent/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686ef6d975308326a0f4b11b94b6e351